### PR TITLE
requirements.txt filepath change for pipeline use, remove run file

### DIFF
--- a/image_classification/tensorflow/Dockerfile
+++ b/image_classification/tensorflow/Dockerfile
@@ -28,6 +28,6 @@ RUN pip3 install --upgrade numpy scipy sklearn tensorflow-gpu==1.14.0
 # Mount data into the docker
 ADD . /mlperf
 
-RUN pip3 install -r ./requirements.txt
+RUN pip3 install -r ./image_classification/tensorflow/requirements.txt
 
 ENTRYPOINT ["./docker_entrypoint.sh"]

--- a/image_classification/tensorflow/run_and_time_result.sh
+++ b/image_classification/tensorflow/run_and_time_result.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-./run_and_time.sh 2>&1 | tail -1 >>/tekton/results/current-date-unix-timestamp
-      


### PR DESCRIPTION
run_and_time_result.sh does not work properly. To get logs and results, I added a script in mlperf-tekton.
In the tekton pipeline, the build runs at "trining" level, so the path needs to point to image_classification/tensorflow